### PR TITLE
cds.run(db=>{}) is gone and so it is in init.js

### DIFF
--- a/srv/init.js
+++ b/srv/init.js
@@ -5,9 +5,8 @@ module.exports = db => {
   const { Products, Suppliers } = db.entities(
     'MockEPMProductManagementService'
   )
-
-  DELETE.from(Products+'')
-  INSERT.into(Products).entries(oProducts)
-  DELETE.from(Suppliers+'')
-  INSERT.into(Suppliers).entries(oSuppliers)
+  return cds.run ([
+    INSERT.into(Products).entries(oProducts),
+    INSERT.into(Suppliers).entries(oSuppliers),
+  ])
 }


### PR DESCRIPTION
This should fix https://answers.sap.com/questions/13119509/bug-in-cds-run-with-mocks-in-memory-with-cds-4x.html